### PR TITLE
Removing unnecessary check for 0

### DIFF
--- a/ios/RangeSlider/RangeSlider.m
+++ b/ios/RangeSlider/RangeSlider.m
@@ -171,8 +171,8 @@
         _rangeSlider = [[TTRangeSlider alloc] initWithFrame:CGRectZero];
         _rangeSlider.minValue = _minValue ? _minValue:0;
         _rangeSlider.maxValue = _maxValue ? _maxValue:100;
-        _rangeSlider.selectedMinimum = _selectedMinimum? _selectedMinimum:20;
-        _rangeSlider.selectedMaximum = _selectedMaximum? _selectedMaximum:60;
+        _rangeSlider.selectedMinimum = _selectedMinimum;
+        _rangeSlider.selectedMaximum = _selectedMaximum;
 
         // _rangeSlider.minDistance = -1; // distance between selectedMin_selected_max
         // _rangeSlider.handleColor = [UIColor colorWithRed:0.23 green:0.75 blue:0.43 alpha:1.0];


### PR DESCRIPTION
There doesn't seem to be any need for a  check for `0` for the selectedMinimum and selectedMaximum values. There are scenarios where the slider is expected to have `0` value, but as soon as the user currently slides the slider the `0`, it snaps to `20` or `60`.

Example code to reproduce the error:
```jsx
<RangeSlider
              minValue={0}
              maxValue={250}
              selectedMinimum={0}
              tintColor={'#3870e4'}
              tintColorBetweenHandles={'#3870e4'}
              disableRange={true}
              style={{ height: 70, backgroundColor: 'white' }}
              onChange={(data) => { console.log(data); }}
            />
```

This code snaps the single slider from `0` to `20`